### PR TITLE
Feat: DC-05 Complete REST API layer for tasks, sprints, and activity …

### DIFF
--- a/ecoservants-scrum-board.php
+++ b/ecoservants-scrum-board.php
@@ -604,18 +604,20 @@ function es_scrum_render_settings_page()
  */
 function es_scrum_register_rest_routes()
 {
-    // 1. Task API: Use dedicated class
+    // Load shared response helper
+    require_once plugin_dir_path(__FILE__) . 'includes/api/class-api-response.php';
+
+    // 1. Task API
     require_once plugin_dir_path(__FILE__) . 'includes/api/class-scrum-board-api.php';
     $task_api = new EcoServants_Scrum_Board_API();
     $task_api->register_routes();
 
-    // 2. Sprint API: Use dedicated class
-    if (file_exists(plugin_dir_path(__FILE__) . 'includes/api/class-sprint-api.php')) {
-        $sprint_api = new EcoServants_Sprint_API();
-        $sprint_api->register_routes();
-    }
+    // 2. Sprint API
+    require_once plugin_dir_path(__FILE__) . 'includes/api/class-sprint-api.php';
+    $sprint_api = new EcoServants_Sprint_API();
+    $sprint_api->register_routes();
 
-    // 3. Board Config API: Use dedicated class
+    // 3. Board Config API
     if (file_exists(plugin_dir_path(__FILE__) . 'includes/api/class-board-config-api.php')) {
         require_once plugin_dir_path(__FILE__) . 'includes/api/class-board-config-api.php';
         $config_api = new EcoServants_Board_Config_API();
@@ -629,21 +631,15 @@ function es_scrum_register_rest_routes()
         $profile_api->register_routes();
     }
 
-    // Ping route
-    register_rest_route(
-        'es-scrum/v1',
-        '/ping',
-        array(
-            'methods' => 'GET',
-            'callback' => 'es_scrum_rest_ping',
-            'permission_callback' => '__return_true', // Public ping for connectivity check
-        )
-    );
-
-    // 3. Comment API: Use dedicated class
+    // 3. Comment API
     require_once plugin_dir_path(__FILE__) . 'includes/api/class-comment-api.php';
     $comment_api = new EcoServants_Comment_API();
     $comment_api->register_routes();
+
+    // 4. Activity Log API
+    require_once plugin_dir_path(__FILE__) . 'includes/api/class-activity-log-api.php';
+    $activity_api = new EcoServants_Activity_Log_API();
+    $activity_api->register_routes();
 
     // DC-11: Recommendations
     register_rest_route(
@@ -666,7 +662,7 @@ function es_scrum_register_rest_routes()
             'methods' => 'POST',
             'callback' => 'es_scrum_rest_claim_task',
             'permission_callback' => function () {
-                return current_user_can('read'); // Basic permission
+                return current_user_can('read');
             },
         )
     );
@@ -681,6 +677,17 @@ function es_scrum_register_rest_routes()
                 'callback' => 'es_scrum_rest_get_activity',
                 'permission_callback' => 'es_scrum_rest_permission_check',
             ),
+        )
+    );
+
+    // Ping route (public)
+    register_rest_route(
+        'es-scrum/v1',
+        '/ping',
+        array(
+            'methods'             => 'GET',
+            'callback'            => 'es_scrum_rest_ping',
+            'permission_callback' => '__return_true',
         )
     );
 }
@@ -707,10 +714,28 @@ function es_scrum_rest_ping(WP_REST_Request $request)
 }
 
 
+/**
+ * Log an activity entry for a task.
+ *
+ * @param int    $task_id    The task ID.
+ * @param int    $user_id    The user performing the action.
+ * @param string $action     The action name (e.g., 'created', 'status_change').
+ * @param string $from_value Previous value (if applicable).
+ * @param string $to_value   New value (if applicable).
+ */
+function es_scrum_log_activity( $task_id, $user_id, $action, $from_value = '', $to_value = '' ) {
+    $db    = es_scrum_db();
+    $table = es_scrum_table_name( 'activity_log' );
 
-
-
-
+    $db->insert( $table, array(
+        'task_id'    => absint( $task_id ),
+        'user_id'    => absint( $user_id ),
+        'action'     => sanitize_text_field( $action ),
+        'from_value' => sanitize_text_field( $from_value ),
+        'to_value'   => sanitize_text_field( $to_value ),
+        'created_at' => current_time( 'mysql' ),
+    ) );
+}
 
 /**
  * Handles comment mentions by sending email notifications.
@@ -861,43 +886,6 @@ function es_scrum_rest_claim_task(WP_REST_Request $request)
         'success' => true,
         'message' => 'Task claimed successfully',
         'task_id' => $task_id,
-    );
-}
-
-/**
- * Helper: Get user's program group
- * Assuming user meta 'es_program_groups' holds the slug
- */
-function es_scrum_get_user_program_group($user_id)
-{
-    // This could return an array or single string. For DC-11 we assume single primary group for simplicity.
-    // Adapting based on 'DC-03' which mentions 'es_program_groups'.
-    $groups = get_user_meta($user_id, 'es_program_groups', true);
-    if (is_array($groups) && !empty($groups)) {
-        return $groups[0];
-    }
-    return $groups; // If string
-}
-
-/**
- * Helper: Log activity
- */
-function es_scrum_log_activity($task_id, $user_id, $action, $from, $to)
-{
-    global $wpdb;
-    $table_activity = es_scrum_table_name('activity_log');
-
-    $wpdb->insert(
-        $table_activity,
-        array(
-            'task_id' => $task_id,
-            'user_id' => $user_id,
-            'action' => $action,
-            'from_value' => $from,
-            'to_value' => $to,
-            'created_at' => current_time('mysql'),
-        ),
-        array('%d', '%d', '%s', '%s', '%s', '%s')
     );
 }
 

--- a/ecoservants-scrum-board.php
+++ b/ecoservants-scrum-board.php
@@ -631,12 +631,12 @@ function es_scrum_register_rest_routes()
         $profile_api->register_routes();
     }
 
-    // 3. Comment API
+    // 5. Comment API
     require_once plugin_dir_path(__FILE__) . 'includes/api/class-comment-api.php';
     $comment_api = new EcoServants_Comment_API();
     $comment_api->register_routes();
 
-    // 4. Activity Log API
+    // 6. Activity Log API (registers GET + POST /activity)
     require_once plugin_dir_path(__FILE__) . 'includes/api/class-activity-log-api.php';
     $activity_api = new EcoServants_Activity_Log_API();
     $activity_api->register_routes();
@@ -667,18 +667,7 @@ function es_scrum_register_rest_routes()
         )
     );
 
-    // Activity Log Collection
-    register_rest_route(
-        'es-scrum/v1',
-        '/activity',
-        array(
-            array(
-                'methods' => 'GET',
-                'callback' => 'es_scrum_rest_get_activity',
-                'permission_callback' => 'es_scrum_rest_permission_check',
-            ),
-        )
-    );
+    // NOTE: /activity routes (GET + POST) are registered by EcoServants_Activity_Log_API above.
 
     // Ping route (public)
     register_rest_route(

--- a/ecoservants-scrum-board.php
+++ b/ecoservants-scrum-board.php
@@ -986,3 +986,18 @@ function es_scrum_rest_get_activity(WP_REST_Request $request)
 
     return $response;
 }
+
+/**
+ * Get the program group slug associated with a user.
+ * 
+ * @param int $user_id User ID
+ * @return string|null Slug of program group, or null if none.
+ */
+function es_scrum_get_user_program_group($user_id)
+{
+    $groups = get_user_meta($user_id, 'es_program_groups', true);
+    if (is_array($groups) && !empty($groups)) {
+        return $groups[0];
+    }
+    return $groups;
+}

--- a/ecoservants-scrum-board.php
+++ b/ecoservants-scrum-board.php
@@ -607,6 +607,9 @@ function es_scrum_register_rest_routes()
     // Load shared response helper
     require_once plugin_dir_path(__FILE__) . 'includes/api/class-api-response.php';
 
+    // Load security middleware
+    require_once plugin_dir_path(__FILE__) . 'includes/api/class-api-security.php';
+
     // 1. Task API
     require_once plugin_dir_path(__FILE__) . 'includes/api/class-scrum-board-api.php';
     $task_api = new EcoServants_Scrum_Board_API();
@@ -969,7 +972,8 @@ function es_scrum_rest_get_activity(WP_REST_Request $request)
         return new WP_Error('missing_param', 'Task ID is required', array('status' => 400));
     }
 
-    $page = $request->get_param('page') ? absint($request->get_param('page')) : 1;
+    $raw_page = $request->get_param('page');
+    $page = max(1, (int) $raw_page);
     $per_page = $request->get_param('per_page') ? absint($request->get_param('per_page')) : 20;
     $offset = ($page - 1) * $per_page;
 

--- a/includes/api/class-activity-log-api.php
+++ b/includes/api/class-activity-log-api.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * REST API Controller for EcoServants Activity Log
+ *
+ * Provides read access to activity logs with pagination and filtering.
+ * Replaces the inline function previously in the main plugin file.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class EcoServants_Activity_Log_API extends WP_REST_Controller {
+
+    public function __construct() {
+        $this->namespace = 'es-scrum/v1';
+        $this->rest_base = 'activity';
+    }
+
+    /**
+     * Register the routes
+     */
+    public function register_routes() {
+        // Collection routes
+        register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+            array(
+                'methods'             => 'GET',
+                'callback'            => array( $this, 'get_items' ),
+                'permission_callback' => array( $this, 'get_items_permissions_check' ),
+            ),
+            array(
+                'methods'             => 'POST',
+                'callback'            => array( $this, 'create_item' ),
+                'permission_callback' => array( $this, 'create_item_permissions_check' ),
+            ),
+        ) );
+    }
+
+    // ──────────────────────────────────────────────
+    //  PERMISSIONS
+    // ──────────────────────────────────────────────
+
+    public function get_items_permissions_check( $request ) {
+        return es_scrum_rest_permission_check();
+    }
+
+    public function create_item_permissions_check( $request ) {
+        return current_user_can( 'edit_posts' );
+    }
+
+    // ──────────────────────────────────────────────
+    //  GET /activity — List activity with pagination & filters
+    // ──────────────────────────────────────────────
+
+    public function get_items( $request ) {
+        $db    = es_scrum_db();
+        $table = es_scrum_table_name( 'activity_log' );
+        $pag   = EcoServants_API_Response::parse_pagination( $request );
+
+        $where = 'WHERE 1=1';
+        $args  = array();
+
+        // Filter by task_id (required for task-level view)
+        $task_id = $request->get_param( 'task_id' );
+        if ( ! empty( $task_id ) ) {
+            $where .= ' AND task_id = %d';
+            $args[] = absint( $task_id );
+        }
+
+        // Filter by user_id
+        $user_id = $request->get_param( 'user_id' );
+        if ( ! empty( $user_id ) ) {
+            $where .= ' AND user_id = %d';
+            $args[] = absint( $user_id );
+        }
+
+        // Filter by action type
+        $action = $request->get_param( 'action' );
+        if ( ! empty( $action ) ) {
+            $where .= ' AND action = %s';
+            $args[] = sanitize_text_field( $action );
+        }
+
+        // Data query
+        $sql    = "SELECT * FROM {$table} {$where} ORDER BY created_at DESC LIMIT %d OFFSET %d";
+        $args[] = $pag['per_page'];
+        $args[] = $pag['offset'];
+
+        $activity = $db->get_results( $db->prepare( $sql, $args ) );
+
+        // Count query
+        $count_args = array();
+        if ( ! empty( $task_id ) ) {
+            $count_args[] = absint( $task_id );
+        }
+        if ( ! empty( $user_id ) ) {
+            $count_args[] = absint( $user_id );
+        }
+        if ( ! empty( $action ) ) {
+            $count_args[] = sanitize_text_field( $action );
+        }
+
+        $count_sql = "SELECT COUNT(*) FROM {$table} {$where}";
+        if ( ! empty( $count_args ) ) {
+            $total = (int) $db->get_var( $db->prepare( $count_sql, $count_args ) );
+        } else {
+            $total = (int) $db->get_var( "SELECT COUNT(*) FROM {$table}" );
+        }
+
+        return EcoServants_API_Response::paginated( $activity, $total, $pag['page'], $pag['per_page'] );
+    }
+
+    // ──────────────────────────────────────────────
+    //  POST /activity — Create a manual log entry
+    // ──────────────────────────────────────────────
+
+    public function create_item( $request ) {
+        $params = $request->get_json_params();
+
+        $task_id = ! empty( $params['task_id'] ) ? absint( $params['task_id'] ) : null;
+        $action  = ! empty( $params['action'] ) ? sanitize_text_field( $params['action'] ) : '';
+
+        if ( empty( $action ) ) {
+            return EcoServants_API_Response::error( 'missing_action', 'Action is required' );
+        }
+
+        $db    = es_scrum_db();
+        $table = es_scrum_table_name( 'activity_log' );
+
+        $data = array(
+            'task_id'    => $task_id,
+            'user_id'    => get_current_user_id(),
+            'action'     => $action,
+            'from_value' => isset( $params['from_value'] ) ? sanitize_text_field( $params['from_value'] ) : '',
+            'to_value'   => isset( $params['to_value'] ) ? sanitize_text_field( $params['to_value'] ) : '',
+            'created_at' => current_time( 'mysql' ),
+        );
+
+        $result = $db->insert( $table, $data );
+
+        if ( false === $result ) {
+            return EcoServants_API_Response::error( 'db_error', 'Could not create activity log entry', 500 );
+        }
+
+        $new_id = $db->insert_id;
+        $entry  = $db->get_row( $db->prepare( "SELECT * FROM {$table} WHERE id = %d", $new_id ) );
+
+        return EcoServants_API_Response::success( $entry, 201 );
+    }
+}

--- a/includes/api/class-activity-log-api.php
+++ b/includes/api/class-activity-log-api.php
@@ -44,6 +44,13 @@ class EcoServants_Activity_Log_API extends WP_REST_Controller {
         return es_scrum_rest_permission_check();
     }
 
+    /**
+     * Permission check for POST /activity.
+     *
+     * Intentionally restricted to users with 'edit_posts' (Contributor level and above).
+     * Plain subscribers (read-only) cannot write activity log entries directly.
+     * All write requests must also carry a valid WP REST nonce.
+     */
     public function create_item_permissions_check( $request ) {
         return current_user_can( 'edit_posts' );
     }

--- a/includes/api/class-api-response.php
+++ b/includes/api/class-api-response.php
@@ -62,8 +62,10 @@ class EcoServants_API_Response {
      * @return array { page: int, per_page: int, offset: int }
      */
     public static function parse_pagination( $request, $default_per_page = 20, $max_per_page = 100 ) {
-        // Enforce minimum of 1 so page=0 never produces a negative SQL OFFSET.
-        $page     = max( 1, absint( $request->get_param( 'page' ) ?? 1 ) );
+        // Explicitly cast to integer and enforce a minimum of 1.
+        $raw_page = $request->get_param( 'page' );
+        $page     = max( 1, (int) $raw_page );
+        
         $per_page = $request->get_param( 'per_page' ) ? absint( $request->get_param( 'per_page' ) ) : $default_per_page;
 
         // Cap per_page to prevent abuse

--- a/includes/api/class-api-response.php
+++ b/includes/api/class-api-response.php
@@ -69,7 +69,7 @@ class EcoServants_API_Response {
         $per_page = $request->get_param( 'per_page' ) ? absint( $request->get_param( 'per_page' ) ) : $default_per_page;
 
         // Cap per_page to prevent abuse
-        $per_page = min( $per_page, $max_per_page );
+        $per_page = max( 1, min( $per_page, $max_per_page ) );
         $offset   = ( $page - 1 ) * $per_page;
 
         return array(

--- a/includes/api/class-api-response.php
+++ b/includes/api/class-api-response.php
@@ -62,7 +62,8 @@ class EcoServants_API_Response {
      * @return array { page: int, per_page: int, offset: int }
      */
     public static function parse_pagination( $request, $default_per_page = 20, $max_per_page = 100 ) {
-        $page     = $request->get_param( 'page' ) ? absint( $request->get_param( 'page' ) ) : 1;
+        // Enforce minimum of 1 so page=0 never produces a negative SQL OFFSET.
+        $page     = max( 1, absint( $request->get_param( 'page' ) ?? 1 ) );
         $per_page = $request->get_param( 'per_page' ) ? absint( $request->get_param( 'per_page' ) ) : $default_per_page;
 
         // Cap per_page to prevent abuse

--- a/includes/api/class-api-response.php
+++ b/includes/api/class-api-response.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Standardized API Response Helpers for EcoServants Scrum Board
+ *
+ * Provides consistent JSON response formatting across all REST endpoints.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class EcoServants_API_Response {
+
+    /**
+     * Create a success response.
+     *
+     * @param mixed $data   Response data.
+     * @param int   $status HTTP status code.
+     * @return WP_REST_Response
+     */
+    public static function success( $data, $status = 200 ) {
+        return new WP_REST_Response( $data, $status );
+    }
+
+    /**
+     * Create an error response.
+     *
+     * @param string $code    Error code identifier.
+     * @param string $message Human-readable error message.
+     * @param int    $status  HTTP status code.
+     * @return WP_Error
+     */
+    public static function error( $code, $message, $status = 400 ) {
+        return new WP_Error( $code, $message, array( 'status' => $status ) );
+    }
+
+    /**
+     * Create a paginated response with standard WP headers.
+     *
+     * @param array $data     Array of result items.
+     * @param int   $total    Total number of items across all pages.
+     * @param int   $page     Current page number.
+     * @param int   $per_page Items per page.
+     * @return WP_REST_Response
+     */
+    public static function paginated( $data, $total, $page, $per_page ) {
+        $max_pages = ceil( $total / $per_page );
+
+        $response = rest_ensure_response( $data );
+        $response->header( 'X-WP-Total', (int) $total );
+        $response->header( 'X-WP-TotalPages', (int) $max_pages );
+
+        return $response;
+    }
+
+    /**
+     * Parse pagination parameters from a request.
+     *
+     * @param WP_REST_Request $request The REST request.
+     * @param int             $default_per_page Default items per page.
+     * @param int             $max_per_page Maximum allowed items per page.
+     * @return array { page: int, per_page: int, offset: int }
+     */
+    public static function parse_pagination( $request, $default_per_page = 20, $max_per_page = 100 ) {
+        $page     = $request->get_param( 'page' ) ? absint( $request->get_param( 'page' ) ) : 1;
+        $per_page = $request->get_param( 'per_page' ) ? absint( $request->get_param( 'per_page' ) ) : $default_per_page;
+
+        // Cap per_page to prevent abuse
+        $per_page = min( $per_page, $max_per_page );
+        $offset   = ( $page - 1 ) * $per_page;
+
+        return array(
+            'page'     => $page,
+            'per_page' => $per_page,
+            'offset'   => $offset,
+        );
+    }
+}

--- a/includes/api/class-scrum-board-api.php
+++ b/includes/api/class-scrum-board-api.php
@@ -1,17 +1,18 @@
 <?php
 /**
- * REST API Controller for EcoServants Scrum Board
+ * REST API Controller for EcoServants Scrum Board Tasks
+ *
+ * Provides complete CRUD operations for tasks with real database queries,
+ * pagination, filtering, and standardized responses.
  */
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-class EcoServants_Scrum_Board_API extends WP_REST_Controller
-{
+class EcoServants_Scrum_Board_API extends WP_REST_Controller {
 
-    public function __construct()
-    {
+    public function __construct() {
         $this->namespace = 'es-scrum/v1';
         $this->rest_base = 'tasks';
     }
@@ -19,237 +20,321 @@ class EcoServants_Scrum_Board_API extends WP_REST_Controller
     /**
      * Register the routes
      */
-    public function register_routes()
-    {
-        register_rest_route($this->namespace, '/' . $this->rest_base, array(
+    public function register_routes() {
+        // Collection routes: GET (list) and POST (create)
+        register_rest_route( $this->namespace, '/' . $this->rest_base, array(
             array(
-                'methods' => 'GET',
-                'callback' => array($this, 'get_items'),
-                'permission_callback' => array($this, 'get_items_permissions_check'),
+                'methods'             => 'GET',
+                'callback'            => array( $this, 'get_items' ),
+                'permission_callback' => array( $this, 'get_items_permissions_check' ),
             ),
             array(
-                'methods' => 'POST',
-                'callback' => array($this, 'create_item'),
-                'permission_callback' => array($this, 'create_item_permissions_check'),
+                'methods'             => 'POST',
+                'callback'            => array( $this, 'create_item' ),
+                'permission_callback' => array( $this, 'create_item_permissions_check' ),
             ),
-        ));
+        ) );
 
-        register_rest_route($this->namespace, '/' . $this->rest_base . '/(?P<id>[\d]+)', array(
+        // Single item routes: GET, PATCH, DELETE
+        register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<id>[\d]+)', array(
             array(
-                'methods' => 'PATCH',
-                'callback' => array($this, 'update_item'),
-                'permission_callback' => array($this, 'update_item_permissions_check'),
+                'methods'             => 'GET',
+                'callback'            => array( $this, 'get_item' ),
+                'permission_callback' => array( $this, 'get_items_permissions_check' ),
+                'args'                => array(
+                    'id' => array(
+                        'validate_callback' => function( $param ) {
+                            return is_numeric( $param );
+                        },
+                    ),
+                ),
             ),
             array(
-                'methods' => 'DELETE',
-                'callback' => array($this, 'delete_item'),
-                'permission_callback' => array($this, 'delete_item_permissions_check'),
+                'methods'             => array( 'PUT', 'PATCH' ),
+                'callback'            => array( $this, 'update_item' ),
+                'permission_callback' => array( $this, 'update_item_permissions_check' ),
+                'args'                => array(
+                    'id' => array(
+                        'validate_callback' => function( $param ) {
+                            return is_numeric( $param );
+                        },
+                    ),
+                ),
             ),
-        ));
+            array(
+                'methods'             => 'DELETE',
+                'callback'            => array( $this, 'delete_item' ),
+                'permission_callback' => array( $this, 'delete_item_permissions_check' ),
+                'args'                => array(
+                    'id' => array(
+                        'validate_callback' => function( $param ) {
+                            return is_numeric( $param );
+                        },
+                    ),
+                ),
+            ),
+        ) );
     }
 
-    /**
-     * PERMISSIONS
-     */
-    public function get_items_permissions_check($request)
-    {
-        return true;
+    // ──────────────────────────────────────────────
+    //  PERMISSIONS
+    // ──────────────────────────────────────────────
+
+    public function get_items_permissions_check( $request ) {
+        return es_scrum_rest_permission_check();
     }
 
-    public function create_item_permissions_check($request)
-    {
-        return current_user_can('edit_posts');
+    public function create_item_permissions_check( $request ) {
+        return current_user_can( 'edit_posts' );
     }
 
-    public function update_item_permissions_check($request)
-    {
-        return current_user_can('edit_posts');
+    public function update_item_permissions_check( $request ) {
+        return current_user_can( 'edit_posts' );
     }
 
-    public function delete_item_permissions_check($request)
-    {
-        return current_user_can('edit_posts');
+    public function delete_item_permissions_check( $request ) {
+        return current_user_can( 'edit_posts' );
     }
 
-    /**
-     * CALLBACKS
-     */
-    public function get_items($request)
-    {
-        $db = es_scrum_db();
-        $table_name = es_scrum_table_name('tasks');
+    // ──────────────────────────────────────────────
+    //  GET /tasks — List tasks with pagination & filters
+    // ──────────────────────────────────────────────
 
-        $page = $request->get_param('page') ? absint($request->get_param('page')) : 1;
-        $per_page = $request->get_param('per_page') ? absint($request->get_param('per_page')) : 50;
-        $offset = ($page - 1) * $per_page;
+    public function get_items( $request ) {
+        $db    = es_scrum_db();
+        $table = es_scrum_table_name( 'tasks' );
+        $pag   = EcoServants_API_Response::parse_pagination( $request, 50 );
 
-        $program_slug = $request->get_param('program_slug'); // Optional filter
+        // Build WHERE clause with optional filters
+        $where = 'WHERE 1=1';
+        $args  = array();
 
-        $where = "WHERE 1=1";
-        $args = array();
+        $filters = array(
+            'status'       => '%s',
+            'program_slug' => '%s',
+            'sprint_id'    => '%d',
+            'assignee_id'  => '%d',
+            'priority'     => '%s',
+            'type'         => '%s',
+        );
 
-        if (!empty($program_slug)) {
-            $where .= " AND program_slug = %s";
-            $args[] = $program_slug;
+        foreach ( $filters as $param => $format ) {
+            $value = $request->get_param( $param );
+            if ( ! empty( $value ) ) {
+                $where .= " AND {$param} = {$format}";
+                $args[] = $value;
+            }
         }
 
-        // Add sorting (default to created_at DESC)
-        $orderby = "ORDER BY created_at DESC";
+        // Data query
+        $sql = "SELECT * FROM {$table} {$where} ORDER BY created_at DESC LIMIT %d OFFSET %d";
+        $args[] = $pag['per_page'];
+        $args[] = $pag['offset'];
 
-        // Add limits
-        $limit = "LIMIT %d OFFSET %d";
-        $args[] = $per_page;
-        $args[] = $offset;
+        $tasks = $db->get_results( $db->prepare( $sql, $args ) );
 
-        $sql = "SELECT * FROM {$table_name} {$where} {$orderby} {$limit}";
-
-        if (!empty($args)) {
-            $sql = $db->prepare($sql, $args);
+        // Count query (must use same WHERE, without LIMIT/OFFSET)
+        $count_args = array();
+        foreach ( $filters as $param => $format ) {
+            $value = $request->get_param( $param );
+            if ( ! empty( $value ) ) {
+                $count_args[] = $value;
+            }
         }
 
-        $tasks = $db->get_results($sql);
-
-        // Get total count
-        if (!empty($program_slug)) {
-            $count_query = "SELECT COUNT(*) FROM {$table_name} WHERE program_slug = %s";
-            $total = $db->get_var($db->prepare($count_query, $program_slug));
+        $count_sql = "SELECT COUNT(*) FROM {$table} {$where}";
+        if ( ! empty( $count_args ) ) {
+            $total = (int) $db->get_var( $db->prepare( $count_sql, $count_args ) );
         } else {
-            $total = $db->get_var("SELECT COUNT(*) FROM {$table_name}");
+            $total = (int) $db->get_var( "SELECT COUNT(*) FROM {$table}" );
         }
-        $max_pages = ceil($total / $per_page);
 
-        $response = new WP_REST_Response($tasks, 200);
-        $response->header('X-WP-Total', (int) $total);
-        $response->header('X-WP-TotalPages', (int) $max_pages);
-
-        return $response;
+        return EcoServants_API_Response::paginated( $tasks, $total, $pag['page'], $pag['per_page'] );
     }
 
-    /**
-     * CREATE ITEM (POST)
-     */
-    public function create_item($request)
-    {
+    // ──────────────────────────────────────────────
+    //  GET /tasks/{id} — Get single task
+    // ──────────────────────────────────────────────
+
+    public function get_item( $request ) {
+        $db    = es_scrum_db();
+        $table = es_scrum_table_name( 'tasks' );
+        $id    = absint( $request->get_param( 'id' ) );
+
+        $task = $db->get_row( $db->prepare( "SELECT * FROM {$table} WHERE id = %d", $id ) );
+
+        if ( ! $task ) {
+            return EcoServants_API_Response::error( 'not_found', 'Task not found', 404 );
+        }
+
+        return rest_ensure_response( $task );
+    }
+
+    // ──────────────────────────────────────────────
+    //  POST /tasks — Create a new task
+    // ──────────────────────────────────────────────
+
+    public function create_item( $request ) {
         $params = $request->get_json_params();
 
-        if (empty($params['title'])) {
-            return new WP_Error('missing_title', 'Title is required', array('status' => 400));
+        if ( empty( $params['title'] ) ) {
+            return EcoServants_API_Response::error( 'missing_title', 'Title is required' );
         }
 
-        $db = es_scrum_db();
-        $table_name = es_scrum_table_name('tasks');
+        $db    = es_scrum_db();
+        $table = es_scrum_table_name( 'tasks' );
+
+        // Resolve program_slug from user's group, fall back to param or default
+        $user_id      = get_current_user_id();
+        $program_slug = ! empty( $params['program_slug'] )
+            ? sanitize_text_field( $params['program_slug'] )
+            : es_scrum_get_user_program_group( $user_id );
+
+        if ( empty( $program_slug ) ) {
+            $program_slug = 'default-program';
+        }
+
+        $now = current_time( 'mysql', 1 );
 
         $data = array(
-            'title' => sanitize_text_field($params['title']),
-            'description' => isset($params['description']) ? sanitize_textarea_field($params['description']) : '',
-            'program_slug' => 'default-program', // TODO: This should be dynamic
-            'status' => isset($params['status']) ? sanitize_text_field($params['status']) : 'todo',
-            'reporter_id' => get_current_user_id(),
-            'created_at' => current_time('mysql', 1),
-            'updated_at' => current_time('mysql', 1),
+            'title'        => sanitize_text_field( $params['title'] ),
+            'description'  => isset( $params['description'] ) ? sanitize_textarea_field( $params['description'] ) : '',
+            'program_slug' => $program_slug,
+            'sprint_id'    => ! empty( $params['sprint_id'] ) ? absint( $params['sprint_id'] ) : null,
+            'status'       => isset( $params['status'] ) ? sanitize_text_field( $params['status'] ) : 'backlog',
+            'priority'     => isset( $params['priority'] ) ? sanitize_text_field( $params['priority'] ) : 'medium',
+            'type'         => isset( $params['type'] ) ? sanitize_text_field( $params['type'] ) : 'task',
+            'reporter_id'  => $user_id,
+            'assignee_id'  => ! empty( $params['assignee_id'] ) ? absint( $params['assignee_id'] ) : null,
+            'story_points' => isset( $params['story_points'] ) ? absint( $params['story_points'] ) : null,
+            'tags'         => isset( $params['tags'] ) ? sanitize_text_field( $params['tags'] ) : null,
+            'due_date'     => ! empty( $params['due_date'] ) ? sanitize_text_field( $params['due_date'] ) : null,
+            'created_at'   => $now,
+            'updated_at'   => $now,
         );
 
-        $result = $db->insert($table_name, $data);
+        $result = $db->insert( $table, $data );
 
-        if ($result === false) {
-            return new WP_Error('db_error', 'Could not create task', array('status' => 500));
+        if ( false === $result ) {
+            return EcoServants_API_Response::error( 'db_error', 'Could not create task', 500 );
         }
 
-        $new_task_id = $db->insert_id;
+        $new_id = $db->insert_id;
 
-        $new_task = array(
-            'id' => $new_task_id,
-            'title' => $data['title'],
-            'description' => $data['description'],
-            'status' => $data['status'],
-            'message' => 'Task created successfully'
-        );
+        // Log activity
+        es_scrum_log_activity( $new_id, $user_id, 'created', '', $data['status'] );
 
-        return new WP_REST_Response($new_task, 201);
+        // Return the full record from DB
+        $task = $db->get_row( $db->prepare( "SELECT * FROM {$table} WHERE id = %d", $new_id ) );
+
+        return EcoServants_API_Response::success( $task, 201 );
     }
 
-    public function update_item($request)
-    {
-        $id = $request->get_param('id');
+    // ──────────────────────────────────────────────
+    //  PATCH /tasks/{id} — Update a task
+    // ──────────────────────────────────────────────
+
+    public function update_item( $request ) {
+        $db    = es_scrum_db();
+        $table = es_scrum_table_name( 'tasks' );
+        $id    = absint( $request->get_param( 'id' ) );
+
+        // Verify task exists
+        $existing = $db->get_row( $db->prepare( "SELECT * FROM {$table} WHERE id = %d", $id ) );
+        if ( ! $existing ) {
+            return EcoServants_API_Response::error( 'not_found', 'Task not found', 404 );
+        }
+
         $params = $request->get_json_params();
-
-        $db = es_scrum_db();
-        $table_name = es_scrum_table_name('tasks');
-
-        // Check availability
-        $exists = $db->get_var($db->prepare("SELECT id FROM {$table_name} WHERE id = %d", $id));
-        if (!$exists) {
-            return new WP_Error('not_found', 'Task not found', array('status' => 404));
+        if ( empty( $params ) ) {
+            return EcoServants_API_Response::error( 'no_data', 'No update data provided' );
         }
 
-        $data = array();
-        $format = array();
-
-        if (isset($params['title'])) {
-            $data['title'] = sanitize_text_field($params['title']);
-            $format[] = '%s';
-        }
-        if (isset($params['description'])) {
-            $data['description'] = sanitize_textarea_field($params['description']);
-            $format[] = '%s';
-        }
-        if (isset($params['status'])) {
-            $data['status'] = sanitize_text_field($params['status']);
-            $format[] = '%s';
-        }
-        if (isset($params['assignee_id'])) {
-            $data['assignee_id'] = absint($params['assignee_id']);
-            $format[] = '%d';
-        }
-        if (isset($params['story_points'])) {
-            $data['story_points'] = absint($params['story_points']);
-            $format[] = '%d';
-        }
-        if (isset($params['due_date'])) {
-            $data['due_date'] = sanitize_text_field($params['due_date']);
-            $format[] = '%s';
-        }
-
-        if (empty($data)) {
-            return new WP_Error('no_data', 'No data to update', array('status' => 400));
-        }
-
-        $data['updated_at'] = current_time('mysql');
-        $format[] = '%s';
-
-        $updated = $db->update(
-            $table_name,
-            $data,
-            array('id' => $id),
-            $format,
-            array('%d')
+        // Build update data from allowed fields
+        $allowed_fields = array(
+            'title'        => 'sanitize_text_field',
+            'description'  => 'sanitize_textarea_field',
+            'status'       => 'sanitize_text_field',
+            'priority'     => 'sanitize_text_field',
+            'type'         => 'sanitize_text_field',
+            'program_slug' => 'sanitize_text_field',
+            'tags'         => 'sanitize_text_field',
+            'due_date'     => 'sanitize_text_field',
         );
 
-        if ($updated === false) {
-            return new WP_Error('db_error', 'Could not update task', array('status' => 500));
+        $update_data = array();
+
+        foreach ( $allowed_fields as $field => $sanitizer ) {
+            if ( isset( $params[ $field ] ) ) {
+                $update_data[ $field ] = call_user_func( $sanitizer, $params[ $field ] );
+            }
         }
 
-        return new WP_REST_Response(array('message' => 'Task updated', 'id' => $id), 200);
+        // Integer fields handled separately
+        $int_fields = array( 'assignee_id', 'sprint_id', 'story_points' );
+        foreach ( $int_fields as $field ) {
+            if ( isset( $params[ $field ] ) ) {
+                $update_data[ $field ] = $params[ $field ] === null ? null : absint( $params[ $field ] );
+            }
+        }
+
+        if ( empty( $update_data ) ) {
+            return EcoServants_API_Response::error( 'no_valid_fields', 'No valid fields to update' );
+        }
+
+        // Always update the timestamp
+        $update_data['updated_at'] = current_time( 'mysql', 1 );
+
+        $updated = $db->update( $table, $update_data, array( 'id' => $id ) );
+
+        if ( false === $updated ) {
+            return EcoServants_API_Response::error( 'db_error', 'Could not update task', 500 );
+        }
+
+        // Log status change if applicable
+        if ( isset( $update_data['status'] ) && $update_data['status'] !== $existing->status ) {
+            es_scrum_log_activity( $id, get_current_user_id(), 'status_change', $existing->status, $update_data['status'] );
+        }
+
+        // Return the updated record
+        $task = $db->get_row( $db->prepare( "SELECT * FROM {$table} WHERE id = %d", $id ) );
+
+        return rest_ensure_response( $task );
     }
 
-    public function delete_item($request)
-    {
-        $id = $request->get_param('id');
-        $db = es_scrum_db();
-        $table_name = es_scrum_table_name('tasks');
+    // ──────────────────────────────────────────────
+    //  DELETE /tasks/{id} — Delete a task
+    // ──────────────────────────────────────────────
 
-        // Check availability
-        $exists = $db->get_var($db->prepare("SELECT id FROM {$table_name} WHERE id = %d", $id));
-        if (!$exists) {
-            return new WP_Error('not_found', 'Task not found', array('status' => 404));
+    public function delete_item( $request ) {
+        $db    = es_scrum_db();
+        $table = es_scrum_table_name( 'tasks' );
+        $id    = absint( $request->get_param( 'id' ) );
+
+        // Verify task exists
+        $existing = $db->get_row( $db->prepare( "SELECT * FROM {$table} WHERE id = %d", $id ) );
+        if ( ! $existing ) {
+            return EcoServants_API_Response::error( 'not_found', 'Task not found', 404 );
         }
 
-        $deleted = $db->delete($table_name, array('id' => $id), array('%d'));
+        // Cascade delete: remove associated comments
+        $comments_table = es_scrum_table_name( 'comments' );
+        $db->delete( $comments_table, array( 'task_id' => $id ), array( '%d' ) );
 
-        if ($deleted === false) {
-            return new WP_Error('db_error', 'Could not delete task', array('status' => 500));
+        // Cascade delete: remove associated activity log entries
+        $activity_table = es_scrum_table_name( 'activity_log' );
+        $db->delete( $activity_table, array( 'task_id' => $id ), array( '%d' ) );
+
+        // Delete the task itself
+        $deleted = $db->delete( $table, array( 'id' => $id ), array( '%d' ) );
+
+        if ( false === $deleted ) {
+            return EcoServants_API_Response::error( 'db_error', 'Could not delete task', 500 );
         }
 
-        return new WP_REST_Response(array('message' => 'Task deleted', 'id' => $id), 200);
+        return new WP_REST_Response( array(
+            'deleted' => true,
+            'id'      => $id,
+        ), 200 );
     }
 }

--- a/includes/api/class-sprint-api.php
+++ b/includes/api/class-sprint-api.php
@@ -1,6 +1,9 @@
 <?php
 /**
  * REST API Controller for EcoServants Sprints
+ *
+ * Provides complete CRUD operations for sprints with real database queries,
+ * pagination, filtering, and standardized responses.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -14,7 +17,11 @@ class EcoServants_Sprint_API extends WP_REST_Controller {
         $this->rest_base = 'sprints';
     }
 
+    /**
+     * Register the routes
+     */
     public function register_routes() {
+        // Collection routes
         register_rest_route( $this->namespace, '/' . $this->rest_base, array(
             array(
                 'methods'             => 'GET',
@@ -27,78 +34,287 @@ class EcoServants_Sprint_API extends WP_REST_Controller {
                 'permission_callback' => array( $this, 'create_item_permissions_check' ),
             ),
         ) );
+
+        // Single item routes
+        register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<id>[\d]+)', array(
+            array(
+                'methods'             => 'GET',
+                'callback'            => array( $this, 'get_item' ),
+                'permission_callback' => array( $this, 'get_items_permissions_check' ),
+                'args'                => array(
+                    'id' => array(
+                        'validate_callback' => function( $param ) {
+                            return is_numeric( $param );
+                        },
+                    ),
+                ),
+            ),
+            array(
+                'methods'             => array( 'PUT', 'PATCH' ),
+                'callback'            => array( $this, 'update_item' ),
+                'permission_callback' => array( $this, 'update_item_permissions_check' ),
+                'args'                => array(
+                    'id' => array(
+                        'validate_callback' => function( $param ) {
+                            return is_numeric( $param );
+                        },
+                    ),
+                ),
+            ),
+            array(
+                'methods'             => 'DELETE',
+                'callback'            => array( $this, 'delete_item' ),
+                'permission_callback' => array( $this, 'delete_item_permissions_check' ),
+                'args'                => array(
+                    'id' => array(
+                        'validate_callback' => function( $param ) {
+                            return is_numeric( $param );
+                        },
+                    ),
+                ),
+            ),
+        ) );
     }
 
+    // ──────────────────────────────────────────────
+    //  PERMISSIONS
+    // ──────────────────────────────────────────────
+
     public function get_items_permissions_check( $request ) {
-        return true; 
+        return es_scrum_rest_permission_check();
     }
 
     public function create_item_permissions_check( $request ) {
         return current_user_can( 'edit_posts' );
     }
 
-    public function get_items( $request ) {
-        // MOCK DATA
-        $mock_sprints = array(
-            array(
-                'id'        => 101,
-                'name'      => 'Sprint Alpha',
-                'status'    => 'active',
-                'startDate' => '2025-10-01',
-                'endDate'   => '2025-10-14',
-                'goal'      => 'Setup Core Infrastructure'
-            ),
-            array(
-                'id'        => 102,
-                'name'      => 'Sprint Beta',
-                'status'    => 'future',
-                'startDate' => '2025-10-15',
-                'endDate'   => '2025-10-28',
-                'goal'      => 'User Authentication'
-            ),
-        );
-
-        return new WP_REST_Response( array( 'success' => true, 'data' => $mock_sprints ), 200 );
+    public function update_item_permissions_check( $request ) {
+        return current_user_can( 'edit_posts' );
     }
+
+    public function delete_item_permissions_check( $request ) {
+        return current_user_can( 'edit_posts' );
+    }
+
+    // ──────────────────────────────────────────────
+    //  GET /sprints — List sprints with optional filters
+    // ──────────────────────────────────────────────
+
+    public function get_items( $request ) {
+        $db    = es_scrum_db();
+        $table = es_scrum_table_name( 'sprints' );
+        $pag   = EcoServants_API_Response::parse_pagination( $request, 20 );
+
+        $where = 'WHERE 1=1';
+        $args  = array();
+
+        // Optional filters
+        $status = $request->get_param( 'status' );
+        if ( ! empty( $status ) ) {
+            $where .= ' AND status = %s';
+            $args[] = $status;
+        }
+
+        $program_slug = $request->get_param( 'program_slug' );
+        if ( ! empty( $program_slug ) ) {
+            $where .= ' AND program_slug = %s';
+            $args[] = $program_slug;
+        }
+
+        // Data query
+        $sql    = "SELECT * FROM {$table} {$where} ORDER BY created_at DESC LIMIT %d OFFSET %d";
+        $args[] = $pag['per_page'];
+        $args[] = $pag['offset'];
+
+        $sprints = $db->get_results( $db->prepare( $sql, $args ) );
+
+        // Count query
+        $count_args = array();
+        if ( ! empty( $status ) ) {
+            $count_args[] = $status;
+        }
+        if ( ! empty( $program_slug ) ) {
+            $count_args[] = $program_slug;
+        }
+
+        $count_sql = "SELECT COUNT(*) FROM {$table} {$where}";
+        if ( ! empty( $count_args ) ) {
+            $total = (int) $db->get_var( $db->prepare( $count_sql, $count_args ) );
+        } else {
+            $total = (int) $db->get_var( "SELECT COUNT(*) FROM {$table}" );
+        }
+
+        return EcoServants_API_Response::paginated( $sprints, $total, $pag['page'], $pag['per_page'] );
+    }
+
+    // ──────────────────────────────────────────────
+    //  GET /sprints/{id} — Get single sprint
+    // ──────────────────────────────────────────────
+
+    public function get_item( $request ) {
+        $db    = es_scrum_db();
+        $table = es_scrum_table_name( 'sprints' );
+        $id    = absint( $request->get_param( 'id' ) );
+
+        $sprint = $db->get_row( $db->prepare( "SELECT * FROM {$table} WHERE id = %d", $id ) );
+
+        if ( ! $sprint ) {
+            return EcoServants_API_Response::error( 'not_found', 'Sprint not found', 404 );
+        }
+
+        return rest_ensure_response( $sprint );
+    }
+
+    // ──────────────────────────────────────────────
+    //  POST /sprints — Create a sprint
+    // ──────────────────────────────────────────────
 
     public function create_item( $request ) {
         $params = $request->get_json_params();
 
         if ( empty( $params['name'] ) ) {
-            return new WP_Error( 'missing_name', 'Sprint Name is required', array( 'status' => 400 ) );
+            return EcoServants_API_Response::error( 'missing_name', 'Sprint name is required' );
         }
 
-        $db = es_scrum_db();
-        $table_name = es_scrum_table_name( 'sprints' );
+        $db    = es_scrum_db();
+        $table = es_scrum_table_name( 'sprints' );
+
+        // Resolve program_slug
+        $user_id      = get_current_user_id();
+        $program_slug = ! empty( $params['program_slug'] )
+            ? sanitize_text_field( $params['program_slug'] )
+            : es_scrum_get_user_program_group( $user_id );
+
+        if ( empty( $program_slug ) ) {
+            $program_slug = 'default-program';
+        }
 
         $data = array(
-            'name' => sanitize_text_field( $params['name'] ),
-            'program_slug' => 'default-program', // TODO: This should be dynamic
-            'start_date' => ! empty( $params['start_date'] ) ? sanitize_text_field( $params['start_date'] ) : null,
-            'end_date' => ! empty( $params['end_date'] ) ? sanitize_text_field( $params['end_date'] ) : null,
-            'goal' => ! empty( $params['goal'] ) ? sanitize_text_field( $params['goal'] ) : '',
-            'created_by' => get_current_user_id(),
-            'created_at' => current_time( 'mysql', 1 ),
+            'name'         => sanitize_text_field( $params['name'] ),
+            'program_slug' => $program_slug,
+            'start_date'   => ! empty( $params['start_date'] ) ? sanitize_text_field( $params['start_date'] ) : null,
+            'end_date'     => ! empty( $params['end_date'] ) ? sanitize_text_field( $params['end_date'] ) : null,
+            'status'       => isset( $params['status'] ) ? sanitize_text_field( $params['status'] ) : 'planned',
+            'goal'         => ! empty( $params['goal'] ) ? sanitize_textarea_field( $params['goal'] ) : '',
+            'created_by'   => $user_id,
+            'created_at'   => current_time( 'mysql', 1 ),
         );
 
-        $result = $db->insert( $table_name, $data );
+        $result = $db->insert( $table, $data );
 
-        if ( $result === false ) {
-            return new WP_Error( 'db_error', 'Could not create sprint', array( 'status' => 500 ) );
+        if ( false === $result ) {
+            return EcoServants_API_Response::error( 'db_error', 'Could not create sprint', 500 );
         }
 
-        $new_sprint_id = $db->insert_id;
+        $new_id = $db->insert_id;
+        $sprint = $db->get_row( $db->prepare( "SELECT * FROM {$table} WHERE id = %d", $new_id ) );
 
-        $new_sprint = array(
-            'id' => $new_sprint_id,
-            'name' => $data['name'],
-            'status' => 'planned',
-            'start_date' => $data['start_date'],
-            'end_date' => $data['end_date'],
-            'goal' => $data['goal'],
-            'message'   => 'Sprint created successfully'
+        return EcoServants_API_Response::success( $sprint, 201 );
+    }
+
+    // ──────────────────────────────────────────────
+    //  PATCH /sprints/{id} — Update a sprint
+    // ──────────────────────────────────────────────
+
+    public function update_item( $request ) {
+        $db    = es_scrum_db();
+        $table = es_scrum_table_name( 'sprints' );
+        $id    = absint( $request->get_param( 'id' ) );
+
+        // Verify sprint exists
+        $existing = $db->get_row( $db->prepare( "SELECT * FROM {$table} WHERE id = %d", $id ) );
+        if ( ! $existing ) {
+            return EcoServants_API_Response::error( 'not_found', 'Sprint not found', 404 );
+        }
+
+        $params = $request->get_json_params();
+        if ( empty( $params ) ) {
+            return EcoServants_API_Response::error( 'no_data', 'No update data provided' );
+        }
+
+        // Prevent re-activating archived sprints
+        if ( $existing->status === 'archived' && isset( $params['status'] ) && $params['status'] !== 'archived' ) {
+            return EcoServants_API_Response::error(
+                'invalid_transition',
+                'Archived sprints cannot be re-activated'
+            );
+        }
+
+        $allowed_fields = array(
+            'name'       => 'sanitize_text_field',
+            'status'     => 'sanitize_text_field',
+            'start_date' => 'sanitize_text_field',
+            'end_date'   => 'sanitize_text_field',
+            'goal'       => 'sanitize_textarea_field',
         );
 
-        return new WP_REST_Response( $new_sprint, 201 );
+        $update_data = array();
+        foreach ( $allowed_fields as $field => $sanitizer ) {
+            if ( isset( $params[ $field ] ) ) {
+                $update_data[ $field ] = call_user_func( $sanitizer, $params[ $field ] );
+            }
+        }
+
+        if ( empty( $update_data ) ) {
+            return EcoServants_API_Response::error( 'no_valid_fields', 'No valid fields to update' );
+        }
+
+        $updated = $db->update( $table, $update_data, array( 'id' => $id ) );
+
+        if ( false === $updated ) {
+            return EcoServants_API_Response::error( 'db_error', 'Could not update sprint', 500 );
+        }
+
+        // If archiving, unassign tasks from this sprint
+        if ( isset( $update_data['status'] ) && $update_data['status'] === 'archived' ) {
+            $tasks_table = es_scrum_table_name( 'tasks' );
+            $db->update(
+                $tasks_table,
+                array( 'sprint_id' => null ),
+                array( 'sprint_id' => $id ),
+                array( '%s' ),
+                array( '%d' )
+            );
+        }
+
+        $sprint = $db->get_row( $db->prepare( "SELECT * FROM {$table} WHERE id = %d", $id ) );
+
+        return rest_ensure_response( $sprint );
+    }
+
+    // ──────────────────────────────────────────────
+    //  DELETE /sprints/{id} — Delete a sprint
+    // ──────────────────────────────────────────────
+
+    public function delete_item( $request ) {
+        $db    = es_scrum_db();
+        $table = es_scrum_table_name( 'sprints' );
+        $id    = absint( $request->get_param( 'id' ) );
+
+        $existing = $db->get_row( $db->prepare( "SELECT * FROM {$table} WHERE id = %d", $id ) );
+        if ( ! $existing ) {
+            return EcoServants_API_Response::error( 'not_found', 'Sprint not found', 404 );
+        }
+
+        // Unassign tasks from this sprint before deleting
+        $tasks_table = es_scrum_table_name( 'tasks' );
+        $db->update(
+            $tasks_table,
+            array( 'sprint_id' => null ),
+            array( 'sprint_id' => $id ),
+            array( '%s' ),
+            array( '%d' )
+        );
+
+        $deleted = $db->delete( $table, array( 'id' => $id ), array( '%d' ) );
+
+        if ( false === $deleted ) {
+            return EcoServants_API_Response::error( 'db_error', 'Could not delete sprint', 500 );
+        }
+
+        return new WP_REST_Response( array(
+            'deleted' => true,
+            'id'      => $id,
+        ), 200 );
     }
 }

--- a/includes/api/class-user-profile-api.php
+++ b/includes/api/class-user-profile-api.php
@@ -136,7 +136,8 @@ class EcoServants_User_Profile_API extends WP_REST_Controller
     public function get_user_tasks($request)
     {
         $user_id = $request->get_param('id');
-        $page = $request->get_param('page') ? absint($request->get_param('page')) : 1;
+        $raw_page = $request->get_param('page');
+        $page = max(1, (int) $raw_page);
         $per_page = $request->get_param('per_page') ? absint($request->get_param('per_page')) : 10;
         $offset = ($page - 1) * $per_page;
 
@@ -162,7 +163,8 @@ class EcoServants_User_Profile_API extends WP_REST_Controller
     public function get_user_activity($request)
     {
         $user_id = $request->get_param('id');
-        $page = $request->get_param('page') ? absint($request->get_param('page')) : 1;
+        $raw_page = $request->get_param('page');
+        $page = max(1, (int) $raw_page);
         $per_page = $request->get_param('per_page') ? absint($request->get_param('per_page')) : 10;
         $offset = ($page - 1) * $per_page;
 


### PR DESCRIPTION
Resolved #6 

Complete REST API layer replacing all mock data and stubs with real DB operations.

- Task API: Full CRUD with pagination, filters, activity logging, cascade deletes
- Sprint API: Full CRUD with archived sprint protection
- Activity Log API: New dedicated class (extracted from inline function) with pagination
- New standardized response helper with pagination headers
- Fixed public GET /tasks endpoint (was returning data without auth)
- All queries use prepared statements

Tested: Task CRUD ✅ | Sprint CRUD ✅ | Ping ✅ | PHP syntax ✅